### PR TITLE
Fixes display issue where timer floats left

### DIFF
--- a/chrome-extension/css/yt-timer.css
+++ b/chrome-extension/css/yt-timer.css
@@ -2,4 +2,7 @@
 .yt-issue-layout .harvest-timer.styled {
   border-left: 0;
   padding: 4px 6px;
+  border-radius: 0 2px 2px 0;
+  float: none !important;
+  margin-right: 0 !important;
 }

--- a/chrome-extension/css/yt-timer.css
+++ b/chrome-extension/css/yt-timer.css
@@ -1,4 +1,4 @@
-/* Agile popup */
+/* Agile popup, full-screen experimental view */
 .yt-issue-layout .harvest-timer.styled {
   border-left: 0;
   padding: 4px 6px;

--- a/chrome-extension/js/eventPage.js
+++ b/chrome-extension/js/eventPage.js
@@ -57,8 +57,6 @@ function ($, api, utils) {
   function process (id, date) {
     if (!api.isOptionsPresent()) { return }
 
-    console.log('push time to youtrack');
-
     updateTitle()
 
     var cDate = date || +new Date

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -45,5 +45,5 @@
     "chrome_style": true
   },
   "update_url": "https://clients2.google.com/service/update2/crx",
-  "version": "2.5.8.0"
+  "version": "2.5.9.1"
 }

--- a/chrome-extension/youtrack.js
+++ b/chrome-extension/youtrack.js
@@ -140,7 +140,7 @@
         var goAfter =
           item.querySelector('.star_fsi') ||            // full-screen view and edit
                                                         //   ('.issueId' also works pretty well for slightly different position)
-          item.querySelector('yt-issues-more-actions'); // agile popup
+          item.querySelector('yt-issues-more-actions'); // agile popup, experimental full-screen view
         return goAfter.parentNode.insertBefore(timer, goAfter.nextSibling);
       };
 


### PR DESCRIPTION
This somehow broke in the merge -- the timer should be attached to the toolbar in the agile popup and the experimental full-screen view, not floated left. This commit should fix it.

Broken:
<img width="448" alt="screen shot 2018-07-14 at 6 19 50 pm" src="https://user-images.githubusercontent.com/2721220/42726548-770484ca-8796-11e8-9c41-ce92b8ab80cc.png">

Fixed:
<img width="447" alt="screen shot 2018-07-14 at 6 18 45 pm" src="https://user-images.githubusercontent.com/2721220/42726549-7c9755d4-8796-11e8-8ce5-8ef374b01910.png">

Thank you!